### PR TITLE
Add relationship between contacts and users

### DIFF
--- a/app/assets/javascripts/alerts.js
+++ b/app/assets/javascripts/alerts.js
@@ -1,5 +1,7 @@
 $(document).ready(function() {
   setTimeout(function() {
     $('.alert').fadeOut('slow');
-  }, 2000);
+  }, 3000);
+
+  $('#error_explanation').addClass('alert form-alert')
 });

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -1,0 +1,3 @@
+.main-container {
+  height: calc(100vh - 130px);
+}

--- a/app/assets/stylesheets/components/_alerts.scss
+++ b/app/assets/stylesheets/components/_alerts.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   position: absolute;
-  top: 80px;
+  bottom: 115px;
   width: 100%;
   z-index: -1;
 
@@ -11,4 +11,8 @@
     box-shadow: 1px 1px 10px $silver-chalise;
     width: fit-content;
   }
+}
+
+.form-alert {
+  background-color: $mandy;
 }

--- a/app/assets/stylesheets/pages/_contacts.scss
+++ b/app/assets/stylesheets/pages/_contacts.scss
@@ -1,5 +1,6 @@
 .contacts-container {
-  margin-top: 80px;
+  height: calc(100vh - 260px);
+  padding-top: 130px;
 }
 
 .form-container__contacts {

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -2,28 +2,20 @@ class ContactsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_contact, only: [:show, :edit, :update, :destroy]
 
-  # GET /contacts
-  # GET /contacts.json
   def index
-    @contacts = Contact.all
+    @contacts = Contact.all.where(user_id: current_user.id)
   end
 
-  # GET /contacts/1
-  # GET /contacts/1.json
   def show
   end
 
-  # GET /contacts/new
   def new
     @contact = Contact.new
   end
 
-  # GET /contacts/1/edit
   def edit
   end
 
-  # POST /contacts
-  # POST /contacts.json
   def create
     @contact = Contact.new(contact_params)
 
@@ -38,8 +30,6 @@ class ContactsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /contacts/1
-  # PATCH/PUT /contacts/1.json
   def update
     respond_to do |format|
       if @contact.update(contact_params)
@@ -52,8 +42,6 @@ class ContactsController < ApplicationController
     end
   end
 
-  # DELETE /contacts/1
-  # DELETE /contacts/1.json
   def destroy
     @contact.destroy
     respond_to do |format|
@@ -63,13 +51,17 @@ class ContactsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_contact
-      @contact = Contact.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def contact_params
-      params.require(:contact).permit(:name, :last_name, :phone, :company, :email)
+  def set_contact
+    begin
+      @contact = current_user.contacts.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to contacts_path
+      return
     end
+  end
+
+  def contact_params
+    params.require(:contact).permit(:name, :last_name, :phone, :company, :email, :user_id)
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,2 +1,3 @@
 class Contact < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,3 +1,5 @@
 class Contact < ApplicationRecord
   belongs_to :user
+
+  validates :name, :email, :user_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :contacts
 end

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with(model: contact, local: true) do |form| %>
+  <%= form.hidden_field :user_id , :value => current_user.id  %>
   <% if contact.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(contact.errors.count, "error") %> prohibited this contact from being saved:</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,9 @@
         <p class="alert alert-danger"><%= alert %></p>
       <% end %>
     </div>
-    <%= yield %>
+    <div class="main-container">
+      <%= yield %>
+    </div>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/db/migrate/20190322213653_add_user_ref_to_contacts.rb
+++ b/db/migrate/20190322213653_add_user_ref_to_contacts.rb
@@ -1,0 +1,5 @@
+class AddUserRefToContacts < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :contacts, :user, foreign_key: { on_delete: :cascade }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_22_174347) do
+ActiveRecord::Schema.define(version: 2019_03_22_213653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2019_03_22_174347) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_contacts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -37,4 +39,5 @@ ActiveRecord::Schema.define(version: 2019_03_22_174347) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "contacts", "users", on_delete: :cascade
 end


### PR DESCRIPTION
## Summary
Add relationship between Users and Contacts in order to restrict users to only be able to edit their own contacts.

## Changes
- Add reference between Users and Contacts via a foreign key
- Add user id param in the Contact form
- Make some fields mandatory for contacts in order to avoid empty entries
- Customize notifications (they were overlaping the content)